### PR TITLE
New font solver algorithm

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
     "no-shadow": 0,
     "func-names": 0,
     "func-style": 0,
-    "prefer-arrow-callback": 0
+    "prefer-arrow-callback": 0,
+    "no-restricted-syntax": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "serve:dev": "nodemon $2 --exec babel-node",
     "lint": "eslint --cache src test",
     "security": "nsp check",
+    "pretest": "npm run lint",
     "test": "jest",
     "test:coverage": "jest --collectCoverageFrom='src/**/*.js' --coverage",
     "travis:test": "yarn run test",
@@ -25,8 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "browserslist": "^1.7.5",
-    "caniuse-api": "^1.5.3",
-    "combinations": "^0.1.1"
+    "caniuse-api": "^1.5.3"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/src/index-test.js
+++ b/src/index-test.js
@@ -10,7 +10,7 @@ describe('canifont', function () {
     };
     const getSupport = () => supportedBrowsers;
     const fonts = ['ttf'];
-    const expected = [['ttf']];
+    const expected = ['ttf'];
 
     expect(canifont({
       browsers,

--- a/src/solve-fonts-test.js
+++ b/src/solve-fonts-test.js
@@ -9,7 +9,7 @@ describe('solveFonts', function () {
       },
     ];
     const fonts = ['ttf'];
-    const expected = [['ttf']];
+    const expected = ['ttf'];
 
     expect(solveFonts({
       browsers,
@@ -17,15 +17,35 @@ describe('solveFonts', function () {
     })).toEqual(expected);
   });
 
-  it('returns multiple solved fonts', function () {
+  it('returns the newest supported font', function () {
     const browsers = [
       {
         browser: 'chrome',
         supports: ['ttf', 'woff'],
       },
     ];
-    const fonts = ['ttf', 'woff'];
-    const expected = [['ttf'], ['woff']];
+    const fonts = ['woff', 'ttf'];
+    const expected = ['woff'];
+
+    expect(solveFonts({
+      browsers,
+      fonts,
+    })).toEqual(expected);
+  });
+
+  it('returns the minimum list of fonts to support all browsers', function () {
+    const browsers = [
+      {
+        browser: 'chrome',
+        supports: ['ttf', 'svg', 'woff', 'woff2'],
+      },
+      {
+        browser: 'safari',
+        supports: ['ttf', 'svg', 'woff'],
+      },
+    ];
+    const fonts = ['woff2', 'woff', 'ttf'];
+    const expected = ['woff2', 'woff'];
 
     expect(solveFonts({
       browsers,

--- a/src/solve-fonts.js
+++ b/src/solve-fonts.js
@@ -1,30 +1,18 @@
-const combinations = require('combinations');
-
-// XXX: This can be abstracted (naming) since it's just a solver
 module.exports = function solveFonts({
   browsers,
   fonts,
 }) {
-  const minimumFonts = browsers.map(({ supports }) => supports);
-  const alternatives = fonts.map((font) => {
-    return (
-    {
-      font,
-      matches: minimumFonts.map(minimum => minimum.indexOf(font) >= 0),
+  const browsersFonts = browsers.map(browser => browser.supports);
+
+  const required = [];
+  for (const font of fonts) {
+    required.push(font);
+
+    const supportedByAll = browsersFonts.every(supports => supports.indexOf(font) !== -1);
+    if (supportedByAll) {
+      break;
     }
-    );
-  });
-  const scoredCombinations = combinations(alternatives).map((combination) => {
-    const matches = combination.map(({ matches }) => matches).reduce((all, array) => (
-      array.map((a, i) => a || all[i])
-    ), []).filter(a => a);
+  }
 
-    return matches.length === minimumFonts.length && combination.map(({ font }) => font);
-  }).filter(a => a);
-
-  const recordLength = scoredCombinations.reduce((record, combination) => (
-    combination.length < record.length ? combination : record
-  ), new Array(fonts.length)).length;
-
-  return scoredCombinations.filter(combination => combination.length === recordLength);
+  return required;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -935,10 +935,6 @@ colors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
-combinations@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/combinations/-/combinations-0.1.1.tgz#8a18faa7b972d0f962f7a87be1bb9a66c18cb8b2"
-
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"


### PR DESCRIPTION
1. Return array instead of array of arrays.
2. Reverse list of fonts: start from newer/smaller formats. The same
order that is needed for a stylesheet.
3. Prefer newer formats even if not all browsers support them (actually
even it no support but it’s easy to fix if needed).
4. Include older format only when needed (not all browsers support
newer format).

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
